### PR TITLE
Prefix and deaths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>me.sourceform</groupId>
   <artifactId>Prefixes</artifactId>
-  <version>1.0.5</version>
+  <version>2</version>
   <packaging>jar</packaging>
 
   <name>Prefixes</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>me.sourceform</groupId>
   <artifactId>Prefixes</artifactId>
-  <version>1.0.4-BETA-5</version>
+  <version>1.0.4-BETA-6</version>
   <packaging>jar</packaging>
 
   <name>Prefixes</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>me.sourceform</groupId>
   <artifactId>Prefixes</artifactId>
-  <version>1.0.4-BETA-6</version>
+  <version>1.0.5</version>
   <packaging>jar</packaging>
 
   <name>Prefixes</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>me.sourceform</groupId>
   <artifactId>Prefixes</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4-BETA-2</version>
   <packaging>jar</packaging>
 
   <name>Prefixes</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>me.sourceform</groupId>
   <artifactId>Prefixes</artifactId>
-  <version>1.0.4-BETA-3</version>
+  <version>1.0.4-BETA-5</version>
   <packaging>jar</packaging>
 
   <name>Prefixes</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>me.sourceform</groupId>
   <artifactId>Prefixes</artifactId>
-  <version>1.0.4-BETA-2</version>
+  <version>1.0.4-BETA-3</version>
   <packaging>jar</packaging>
 
   <name>Prefixes</name>

--- a/src/main/java/Listeners/PlayerDeathListener.java
+++ b/src/main/java/Listeners/PlayerDeathListener.java
@@ -2,11 +2,11 @@ package Listeners;
 
 import me.sourceform.prefixes.CustomPrefixPlugin;
 import org.bukkit.ChatColor;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.entity.Player;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.ScoreboardManager;
 import org.bukkit.scoreboard.Team;
@@ -25,33 +25,34 @@ public class PlayerDeathListener implements Listener {
         FileConfiguration config = plugin.getConfig();
         String uuid = player.getUniqueId().toString();
 
-        //Increment death count
+        // Increment death count
         int deaths = config.getInt("players." + uuid + ".deaths", 0);
         deaths++;
         config.set("players." + uuid + ".deaths", deaths);
         plugin.saveConfig();
 
-        //Check prefix
-        String prefix = config.getString("players." + uuid + ".prefix", "");
+        // Retrieve prefix
+        String prefix = config.getString("prefixes." + uuid, "");
 
-        // update tab list name
+        // Update tab list name
         setPlayerPrefixAndTabName(player, prefix, deaths);
     }
-    private void setPlayerPrefixAndTabName(Player player, String prefix, int deaths){
+
+    private void setPlayerPrefixAndTabName(Player player, String prefix, int deaths) {
         ScoreboardManager manager = plugin.getServer().getScoreboardManager();
         Scoreboard scoreboard = manager.getMainScoreboard();
         Team team = scoreboard.getTeam(player.getName());
 
-        if(team != null){
+        if (team != null) {
             team.unregister();
         }
 
         team = scoreboard.registerNewTeam(player.getName());
-        team.setPrefix(prefix + ChatColor.WHITE + " ");
+        team.setPrefix(ChatColor.translateAlternateColorCodes('&', prefix) + ChatColor.RESET + " ");
         team.addEntry(player.getName());
 
-        String tabName = prefix + ChatColor.WHITE + player.getName() + ChatColor.RESET + " | Deaths: " + deaths;
+        String tabName = ChatColor.translateAlternateColorCodes('&', prefix)+ ChatColor.WHITE + " " + player.getName() + ChatColor.RESET + " | Deaths: " + deaths;
+        plugin.getLogger().info("Setting tab name: " + tabName);
         player.setPlayerListName(tabName);
     }
-
 }

--- a/src/main/java/Listeners/PlayerDeathListener.java
+++ b/src/main/java/Listeners/PlayerDeathListener.java
@@ -42,17 +42,17 @@ public class PlayerDeathListener implements Listener {
         ScoreboardManager manager = plugin.getServer().getScoreboardManager();
         Scoreboard scoreboard = manager.getMainScoreboard();
         Team team = scoreboard.getTeam(player.getName());
-
+        // Reset prefix
         if (team != null) {
             team.unregister();
         }
-
+        // re-register prefix
         team = scoreboard.registerNewTeam(player.getName());
         team.setPrefix(ChatColor.translateAlternateColorCodes('&', prefix) + ChatColor.RESET + " ");
         team.addEntry(player.getName());
 
+        //Reset tab name
         String tabName = ChatColor.translateAlternateColorCodes('&', prefix)+ ChatColor.WHITE + " " + player.getName() + ChatColor.RESET + " | Deaths: " + deaths;
-        plugin.getLogger().info("Setting tab name: " + tabName);
         player.setPlayerListName(tabName);
     }
 }

--- a/src/main/java/Listeners/PlayerDeathListener.java
+++ b/src/main/java/Listeners/PlayerDeathListener.java
@@ -1,11 +1,15 @@
 package Listeners;
 
 import me.sourceform.prefixes.CustomPrefixPlugin;
+import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.entity.Player;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.ScoreboardManager;
+import org.bukkit.scoreboard.Team;
 
 public class PlayerDeathListener implements Listener {
 
@@ -20,8 +24,34 @@ public class PlayerDeathListener implements Listener {
         Player player = e.getEntity();
         FileConfiguration config = plugin.getConfig();
         String uuid = player.getUniqueId().toString();
+
+        //Increment death count
         int deaths = config.getInt("players." + uuid + ".deaths", 0);
-        config.set("players." + uuid + ".deaths", deaths + 1);
+        deaths++;
+        config.set("players." + uuid + ".deaths", deaths);
         plugin.saveConfig();
+
+        //Check prefix
+        String prefix = config.getString("players." + uuid + ".prefix", "");
+
+        // update tab list name
+        setPlayerPrefixAndTabName(player, prefix, deaths);
     }
+    private void setPlayerPrefixAndTabName(Player player, String prefix, int deaths){
+        ScoreboardManager manager = plugin.getServer().getScoreboardManager();
+        Scoreboard scoreboard = manager.getMainScoreboard();
+        Team team = scoreboard.getTeam(player.getName());
+
+        if(team != null){
+            team.unregister();
+        }
+
+        team = scoreboard.registerNewTeam(player.getName());
+        team.setPrefix(prefix + ChatColor.WHITE + " ");
+        team.addEntry(player.getName());
+
+        String tabName = prefix + ChatColor.WHITE + player.getName() + ChatColor.RESET + " | Deaths: " + deaths;
+        player.setPlayerListName(tabName);
+    }
+
 }

--- a/src/main/java/Listeners/PlayerDeathListener.java
+++ b/src/main/java/Listeners/PlayerDeathListener.java
@@ -1,0 +1,27 @@
+package Listeners;
+
+import me.sourceform.prefixes.CustomPrefixPlugin;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.configuration.file.FileConfiguration;
+
+public class PlayerDeathListener implements Listener {
+
+    private final CustomPrefixPlugin plugin;
+
+    public PlayerDeathListener(CustomPrefixPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerDeath(PlayerDeathEvent e) {
+        Player player = e.getEntity();
+        FileConfiguration config = plugin.getConfig();
+        String uuid = player.getUniqueId().toString();
+        int deaths = config.getInt("players." + uuid + ".deaths", 0);
+        config.set("players." + uuid + ".deaths", deaths + 1);
+        plugin.saveConfig();
+    }
+}

--- a/src/main/java/Listeners/PlayerJoinListener.java
+++ b/src/main/java/Listeners/PlayerJoinListener.java
@@ -1,6 +1,5 @@
 package Listeners;
 
-
 import me.sourceform.prefixes.CustomPrefixPlugin;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -24,11 +23,14 @@ public class PlayerJoinListener implements Listener {
     public void onPlayerJoin(PlayerJoinEvent e) {
         Player player = e.getPlayer();
         FileConfiguration config = plugin.getConfig();
-        String prefix = config.getString("prefixes." + player.getUniqueId().toString(), "");
-        setPlayerPrefix(player, prefix);
+        String uuid = player.getUniqueId().toString();
+        String prefix = config.getString("players." + uuid + ".prefix", "");
+        int deaths = config.getInt("players." + uuid + ".deaths", 0);
+
+        setPlayerPrefixAndTabName(player, prefix, deaths);
     }
 
-    private void setPlayerPrefix(Player player, String prefix) {
+    private void setPlayerPrefixAndTabName(Player player, String prefix, int deaths) {
         ScoreboardManager manager = plugin.getServer().getScoreboardManager();
         Scoreboard scoreboard = manager.getMainScoreboard();
         Team team = scoreboard.getTeam(player.getName());
@@ -39,5 +41,9 @@ public class PlayerJoinListener implements Listener {
 
         team.setPrefix(prefix + ChatColor.RESET);
         team.addEntry(player.getName());
+
+        // Update tab menu name to include prefix and deaths
+        String tabName = prefix + player.getName() + ChatColor.RESET + " | Deaths: " + deaths;
+        player.setPlayerListName(tabName);
     }
 }

--- a/src/main/java/Listeners/PlayerJoinListener.java
+++ b/src/main/java/Listeners/PlayerJoinListener.java
@@ -27,23 +27,26 @@ public class PlayerJoinListener implements Listener {
         String prefix = config.getString("players." + uuid + ".prefix", "");
         int deaths = config.getInt("players." + uuid + ".deaths", 0);
 
-        setPlayerPrefixAndTabName(player, prefix, deaths);
+        setPlayerPrefixAndTabName(prefix, player, deaths);
     }
 
-    private void setPlayerPrefixAndTabName(Player player, String prefix, int deaths) {
+    private void setPlayerPrefixAndTabName(String prefix, Player player, int deaths) {
         ScoreboardManager manager = plugin.getServer().getScoreboardManager();
         Scoreboard scoreboard = manager.getMainScoreboard();
         Team team = scoreboard.getTeam(player.getName());
 
-        if (team == null) {
-            team = scoreboard.registerNewTeam(player.getName());
+        if(team != null) {
+            team.unregister();
         }
 
+        team = scoreboard.registerNewTeam(player.getName());
         team.setPrefix(prefix + ChatColor.RESET);
         team.addEntry(player.getName());
 
         // Update tab menu name to include prefix and deaths
         String tabName = prefix + " " +  ChatColor.RESET + player.getName() + " | Deaths: " + deaths;
+        plugin.getLogger().info("Setting tab name: " +tabName);
         player.setPlayerListName(tabName);
+
     }
 }

--- a/src/main/java/Listeners/PlayerJoinListener.java
+++ b/src/main/java/Listeners/PlayerJoinListener.java
@@ -43,7 +43,7 @@ public class PlayerJoinListener implements Listener {
         team.addEntry(player.getName());
 
         // Update tab menu name to include prefix and deaths
-        String tabName = prefix + player.getName() + ChatColor.RESET + " | Deaths: " + deaths;
+        String tabName = prefix + " " +  ChatColor.RESET + player.getName() + " | Deaths: " + deaths;
         player.setPlayerListName(tabName);
     }
 }

--- a/src/main/java/Listeners/PlayerJoinListener.java
+++ b/src/main/java/Listeners/PlayerJoinListener.java
@@ -26,11 +26,6 @@ public class PlayerJoinListener implements Listener {
         String uuid = player.getUniqueId().toString();
         String prefix = config.getString("prefixes." + uuid, "");
         int deaths = config.getInt("players." + uuid + ".deaths", 0);
-
-        plugin.getLogger().info("Player UUID: " + uuid);
-        plugin.getLogger().info("Prefix: " + prefix);
-        plugin.getLogger().info("Deaths: " + deaths);
-
         setPlayerPrefixAndTabName(player, prefix, deaths);
     }
 
@@ -38,17 +33,16 @@ public class PlayerJoinListener implements Listener {
         ScoreboardManager manager = plugin.getServer().getScoreboardManager();
         Scoreboard scoreboard = manager.getMainScoreboard();
         Team team = scoreboard.getTeam(player.getName());
-
+        //Reset tab menu name
         if (team != null) {
             team.unregister();
         }
-
+        //Re-set prefix
         team = scoreboard.registerNewTeam(player.getName());
         team.setPrefix(ChatColor.translateAlternateColorCodes('&', prefix) + ChatColor.RESET + " ");
         team.addEntry(player.getName());
-
+        //Update tab menu name
         String tabName = ChatColor.translateAlternateColorCodes('&', prefix)+ ChatColor.WHITE + " " + player.getName() + ChatColor.RESET + " | Deaths: " + deaths;
-        plugin.getLogger().info("Setting tab name: " + tabName);
         player.setPlayerListName(tabName);
     }
 }

--- a/src/main/java/Listeners/PlayerJoinListener.java
+++ b/src/main/java/Listeners/PlayerJoinListener.java
@@ -24,29 +24,31 @@ public class PlayerJoinListener implements Listener {
         Player player = e.getPlayer();
         FileConfiguration config = plugin.getConfig();
         String uuid = player.getUniqueId().toString();
-        String prefix = config.getString("players." + uuid + ".prefix", "");
+        String prefix = config.getString("prefixes." + uuid, "");
         int deaths = config.getInt("players." + uuid + ".deaths", 0);
 
-        setPlayerPrefixAndTabName(prefix, player, deaths);
+        plugin.getLogger().info("Player UUID: " + uuid);
+        plugin.getLogger().info("Prefix: " + prefix);
+        plugin.getLogger().info("Deaths: " + deaths);
+
+        setPlayerPrefixAndTabName(player, prefix, deaths);
     }
 
-    private void setPlayerPrefixAndTabName(String prefix, Player player, int deaths) {
+    private void setPlayerPrefixAndTabName(Player player, String prefix, int deaths) {
         ScoreboardManager manager = plugin.getServer().getScoreboardManager();
         Scoreboard scoreboard = manager.getMainScoreboard();
         Team team = scoreboard.getTeam(player.getName());
 
-        if(team != null) {
+        if (team != null) {
             team.unregister();
         }
 
         team = scoreboard.registerNewTeam(player.getName());
-        team.setPrefix(prefix + ChatColor.RESET);
+        team.setPrefix(ChatColor.translateAlternateColorCodes('&', prefix) + ChatColor.RESET + " ");
         team.addEntry(player.getName());
 
-        // Update tab menu name to include prefix and deaths
-        String tabName = prefix + " " +  ChatColor.RESET + player.getName() + " | Deaths: " + deaths;
-        plugin.getLogger().info("Setting tab name: " +tabName);
+        String tabName = ChatColor.translateAlternateColorCodes('&', prefix)+ ChatColor.WHITE + " " + player.getName() + ChatColor.RESET + " | Deaths: " + deaths;
+        plugin.getLogger().info("Setting tab name: " + tabName);
         player.setPlayerListName(tabName);
-
     }
 }

--- a/src/main/java/me/sourceform/prefixes/CustomPrefixPlugin.java
+++ b/src/main/java/me/sourceform/prefixes/CustomPrefixPlugin.java
@@ -2,6 +2,7 @@ package me.sourceform.prefixes;
 
 import Commands.SetPrefixCommand;
 import Listeners.ChatListener;
+import Listeners.PlayerDeathListener;
 import Listeners.PlayerJoinListener;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -17,6 +18,7 @@ public class CustomPrefixPlugin extends JavaPlugin {
         this.getCommand("setprefix").setExecutor(new SetPrefixCommand(this));
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(this), this);
         getServer().getPluginManager().registerEvents(new ChatListener(this), this);
+        getServer().getPluginManager().registerEvents(new PlayerDeathListener(this), this);
     }
 
     @Override

--- a/src/main/java/me/sourceform/prefixes/CustomPrefixPlugin.java
+++ b/src/main/java/me/sourceform/prefixes/CustomPrefixPlugin.java
@@ -26,11 +26,4 @@ public class CustomPrefixPlugin extends JavaPlugin {
         // Save config on disable to ensure any changes are saved
         saveConfig();
     }
-
-    public void updatePlayerPrefix(Player player) {
-        String prefix = getConfig().getString("prefixes." + player.getUniqueId(), "");
-        player.setDisplayName(prefix + player.getName());
-        player.setPlayerListName(prefix + player.getName());
-    }
-
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,4 @@
+players:
+  <player-uuid>:
+    prefix: '<prefix>'
+    deaths: <number-of-deaths>


### PR DESCRIPTION
## Changelog
[2.0.0] - 2024-06-08

**Added**
Death Count Tracking: The plugin now tracks the number of deaths for each player and displays the death count in the tab menu.
Implemented PlayerDeathListener to increment the death count in the config file whenever a player dies.
Updated PlayerJoinListener to display the current death count along with the prefix in the tab menu when a player joins.
Config File Support: Prefixes and player death counts are now stored in the config.yml file.